### PR TITLE
mobile leaderboard styles

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -291,7 +291,7 @@ table,
     width: auto !important;
   }
 
-  .white-scape-normal-mobile {
+  .white-space-normal-mobile {
     white-space: normal !important;
   }
 }

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -282,16 +282,16 @@ table,
   border-radius: $radius;
 }
 
-.whsnw {
+.white-space-nowrap {
   white-space: nowrap;
 }
 
-@media (max-width: 500px) {
-  .wa-xs {
+@media (max-width: $tablet) {
+  .width-auto-mobile {
     width: auto !important;
   }
 
-  .whsn-xs {
+  .white-scape-normal-mobile {
     white-space: normal !important;
   }
 }

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -281,3 +281,17 @@ table,
 .tab img {
   border-radius: $radius;
 }
+
+.whsnw {
+  white-space: nowrap;
+}
+
+@media (max-width: 500px) {
+  .wa-xs {
+    width: auto !important;
+  }
+
+  .whsn-xs {
+    white-space: normal !important;
+  }
+}

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -294,4 +294,8 @@ table,
   .white-space-normal-mobile {
     white-space: normal !important;
   }
+
+  .font-size-1-rem-mobile {
+    font-size: 1rem !important;
+  }
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,7 +53,8 @@ const routes = [
   {
     path: '/active',
     name: 'ActiveUsers',
-    component: () => import(/* webpackChunkName: "leaderboard" */ '../views/ActiveUsers.vue')
+    component: () =>
+      import(/* webpackChunkName: "leaderboard" */ '../views/ActiveUsers.vue')
   },
   {
     path: '/:user_name',

--- a/src/views/ActiveUsers.vue
+++ b/src/views/ActiveUsers.vue
@@ -36,8 +36,8 @@
                   name: 'Character',
                   params: {
                     user_name: user.user_name,
-                    character_slug: '@',
-                  },
+                    character_slug: '@'
+                  }
                 }"
               >
                 <div class="columns is-vcentered">
@@ -69,16 +69,16 @@
 </template>
 
 <script>
-import { HeroNameFilter } from "@/filters";
+import { HeroNameFilter } from '@/filters';
 
 export default {
   filters: {
-    HeroNameFilter,
+    HeroNameFilter
   },
-  name: "ActiveUsers",
+  name: 'ActiveUsers',
   data() {
     return {
-      activeUsers: [],
+      activeUsers: []
     };
   },
   async mounted() {
@@ -93,7 +93,7 @@ export default {
       const res = await fetch(`${process.env.VUE_APP_API_URL}/active-users`);
       this.activeUsers = await res.json();
       console.log(this.activeUsers);
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/views/Leaderboard.vue
+++ b/src/views/Leaderboard.vue
@@ -135,7 +135,7 @@
                       imgClass="flag"
                       :code="run.speedrun_user_country_code"
                     />
-                    <p class="subtitle is-5">
+                    <p class="subtitle is-5 font-size-1-rem-mobile">
                       <a
                         v-if="!run.user_id"
                         :style="`color: ${run.speedrun_user_dark_color_from};`"
@@ -175,7 +175,9 @@
                     </p>
                   </td>
                   <td class="has-text-centered has-text-right-mobile">
-                    <p class="subtitle is-5 white-space-nowrap">
+                    <p
+                      class="subtitle is-5 white-space-nowrap font-size-1-rem-mobile"
+                    >
                       <a :href="run.speedrun_link" target="_blank">
                         {{ run.seconds_played | DurationFilter }}
                       </a>
@@ -190,7 +192,7 @@
                     >
                     <span
                       :class="
-                        `is-hidden-desktop has-hero ${run.hero} subtitle is-5`
+                        `is-hidden-desktop font-size-1-rem-mobile has-hero ${run.hero} subtitle is-5`
                       "
                       >{{ run.hero }}</span
                     >

--- a/src/views/Leaderboard.vue
+++ b/src/views/Leaderboard.vue
@@ -129,7 +129,7 @@
                     </p>
                   </td>
                   <td
-                    class="is-narrow white-scape-normal-mobile width-auto-mobile"
+                    class="is-narrow white-space-normal-mobile width-auto-mobile"
                   >
                     <CountryIcon
                       imgClass="flag"

--- a/src/views/Leaderboard.vue
+++ b/src/views/Leaderboard.vue
@@ -128,7 +128,7 @@
                       {{ index + 1 }}
                     </p>
                   </td>
-                  <td class="is-narrow">
+                  <td class="is-narrow wa-xs whsn-xs">
                     <CountryIcon
                       imgClass="flag"
                       :code="run.speedrun_user_country_code"
@@ -173,7 +173,7 @@
                     </p>
                   </td>
                   <td class="has-text-centered has-text-right-mobile">
-                    <p class="subtitle is-5">
+                    <p class="subtitle is-5 whsnw">
                       <a :href="run.speedrun_link" target="_blank">
                         {{ run.seconds_played | DurationFilter }}
                       </a>

--- a/src/views/Leaderboard.vue
+++ b/src/views/Leaderboard.vue
@@ -128,7 +128,9 @@
                       {{ index + 1 }}
                     </p>
                   </td>
-                  <td class="is-narrow wa-xs whsn-xs">
+                  <td
+                    class="is-narrow white-scape-normal-mobile width-auto-mobile"
+                  >
                     <CountryIcon
                       imgClass="flag"
                       :code="run.speedrun_user_country_code"
@@ -173,7 +175,7 @@
                     </p>
                   </td>
                   <td class="has-text-centered has-text-right-mobile">
-                    <p class="subtitle is-5 whsnw">
+                    <p class="subtitle is-5 white-space-nowrap">
                       <a :href="run.speedrun_link" target="_blank">
                         {{ run.seconds_played | DurationFilter }}
                       </a>


### PR DESCRIPTION
- prevent time going to 2 lines
- allow runner name to break into multiple lines on mobile
- reduced font size to 1 rem on mobile to be future proof of fancy long names

![mobile_leaderboard](https://user-images.githubusercontent.com/33844718/101523515-60159380-3991-11eb-8de3-8661ed63f4e0.png)

