### PR TITLE
fix animation on safari

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -2,6 +2,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Texturina:ital,wght@0,400;0,500;0,600;0,700;1,100&display=swap");
 
 $title-font: "Texturina", serif;
+$background: hsl(240, 22%, 10%);
 
 body,
 html {
@@ -9,6 +10,8 @@ html {
     font-size: 16px;
 
     --v-anchor-base: var(--v-link-lighten1);
+    // for browser overscroll
+    background: $background;
 }
 
 .dr-nav {
@@ -20,9 +23,21 @@ html {
     line-height: 1.1;
 }
 
+.ovh {
+    overflow: hidden;
+}
+
+.bdrs50p {
+    border-radius: 50%;
+}
+
+.wct {
+    will-change: transform;
+}
+
 .v-application {
     .v-application--wrap {
-        background-color: hsl(240, 22%, 10%);
+        background-color: $background;
         background-image: url("assets/img/body-bg.jpg");
         background-attachment: fixed;
         background-repeat: repeat;

--- a/src/components/VerticalProgress.vue
+++ b/src/components/VerticalProgress.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-bind:style="wrapper">
-    <div v-bind:style="progress"></div>
+  <div v-bind:style="wrapper" class="ovh bdrs50p wct">
+    <div v-bind:style="progress" class="wct"></div>
   </div>
 </template>
 
@@ -46,15 +46,13 @@ export default {
         width: this.size + 'px',
         height: this.size + 'px',
         background: this.$vuetify.theme.themes.dark[this.color],
-        transition: 'all 1s'
+        transition: 'transform 1s'
       };
     },
     wrapper() {
       return {
-        borderRadius: '50%',
         borderWidth: '3px',
         borderStyle: 'solid',
-        overflow: 'hidden',
         width: this.size + 'px',
         height: this.size + 'px',
         borderColor: this.$vuetify.theme.themes.dark.secondary


### PR DESCRIPTION
- fix safari animation border radius start working only after on transition is done
- add few classes by emmet notation, if you paste in css class `bdrs50` add `p` press tab, vscode should expand to `border-radius: 50%;`